### PR TITLE
[nit] fix job name

### DIFF
--- a/.github/workflows/push-when-publishing-from-draft.yaml
+++ b/.github/workflows/push-when-publishing-from-draft.yaml
@@ -9,7 +9,7 @@ on:
       - "draft_entries/**"
 
 jobs:
-  push:
+  push-when-publishing-from-draft:
     uses: hatena/hatenablog-workflows/.github/workflows/push-when-publishing-from-draft.yaml@v1
     with:
       BLOG_DOMAIN: ${{ vars.BLOG_DOMAIN }}


### PR DESCRIPTION
些細な変更ですが、全体的にワークフローのファイル名とjobの名前を一致させているので、直してみました。意図的に現状のようにしているのであればcloseしてください。