### PR TITLE
BLOG_DOMAINとBLOG_OWNER_HATENA_IDに設定すべき値は詳細設定から確認できることを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 1. `blogsync.yaml`の各種項目を記述してください
     - `<BLOG DOMAIN>` にはブログのブログ取得時に設定したドメインを指定してください(独自ドメインではありません)
     - `<BLOG OWNER HATENA ID>` にはブログのオーナー(ブログ作成者)のはてなIDを指定してください
-    - どちらの項目もブログの「詳細設定 > AtomPub > ルートエンドポイント」から確認できます
+    - 上記のどちらの項目もブログの「詳細設定 > AtomPub > ルートエンドポイント」から確認できます。ルートエンドポイントは以下のように構成されています
         - `https://blog.hatena.ne.jp/<BLOG OWNER HATENA ID>/<BLOG DOMAIN>/atom`
 ```yaml
 <BLOG DOMAIN>:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 # セットアップ
 
 1. `blogsync.yaml`の各種項目を記述してください
-    - `<BLOG DOMAIN>` にはブログのドメインを指定してください
+    - `<BLOG DOMAIN>` にはブログのブログ取得時に設定したドメインを指定してください(独自ドメインではありません)
     - `<BLOG OWNER HATENA ID>` にはブログのオーナー(ブログ作成者)のはてなIDを指定してください
+    - どちらの項目もブログの「詳細設定 > AtomPub > ルートエンドポイント」から確認できます
+        - `https://blog.hatena.ne.jp/<BLOG OWNER HATENA ID>/<BLOG DOMAIN>/atom`
 ```yaml
 <BLOG DOMAIN>:
   username: <BLOG OWNER HATENA ID>


### PR DESCRIPTION
https://github.com/hatena/Hatena-Blog-Workflows-Boilerplate/issues/17 の対応
- 設定すべきなのは独自ドメインではないこと
- 設定すべき項目は詳細設定のルートエンドポイントから確認できることを追加