### PR TITLE
hatenablog-workflows v2対応

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/draft.md
+++ b/.github/PULL_REQUEST_TEMPLATE/draft.md
@@ -1,0 +1,4 @@
+## ${TITLE}
+
+- 編集ページのURL: ${EDIT_URL}
+- プレビューへのURL: ${PREVIEW_URL}

--- a/.github/workflows/create-draft.yaml
+++ b/.github/workflows/create-draft.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create-draft:
-    uses: hatena/hatenablog-workflows/.github/workflows/create-draft.yaml@v1
+    uses: hatena/hatenablog-workflows/.github/workflows/create-draft.yaml@fa544a63e845030ff65e35d78847e2bc2cab981e # v2.0.2
     with:
       title: ${{ github.event.inputs.title }}
       draft: true

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   initialize:
-    uses: hatena/hatenablog-workflows/.github/workflows/initialize.yaml@v1
+    uses: hatena/hatenablog-workflows/.github/workflows/initialize.yaml@fa544a63e845030ff65e35d78847e2bc2cab981e # v2.0.2
     with:
       is_draft_included: ${{ inputs.is_draft_included }}
       BLOG_DOMAIN: ${{ vars.BLOG_DOMAIN }}

--- a/.github/workflows/pull-draft.yaml
+++ b/.github/workflows/pull-draft.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pull-draft:
-    uses: hatena/hatenablog-workflows/.github/workflows/pull-draft.yaml@v1
+    uses: hatena/hatenablog-workflows/.github/workflows/pull-draft.yaml@fa544a63e845030ff65e35d78847e2bc2cab981e # v2.0.2
     with:
       title: ${{ github.event.inputs.title }}
       draft: true

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pull:
-    uses: hatena/hatenablog-workflows/.github/workflows/pull.yaml@v1
+    uses: hatena/hatenablog-workflows/.github/workflows/pull.yaml@fa544a63e845030ff65e35d78847e2bc2cab981e # v2.0.2
     with:
       BLOG_DOMAIN: ${{ vars.BLOG_DOMAIN }}
     secrets:

--- a/.github/workflows/push-draft.yaml
+++ b/.github/workflows/push-draft.yaml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   push-draft:
-    uses: hatena/hatenablog-workflows/.github/workflows/push-draft.yaml@v1
+    uses: hatena/hatenablog-workflows/.github/workflows/push-draft.yaml@fa544a63e845030ff65e35d78847e2bc2cab981e # v2.0.2
     secrets:
       OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}

--- a/.github/workflows/push-published-entries.yaml
+++ b/.github/workflows/push-published-entries.yaml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   push-published-entries:
-    uses: hatena/hatenablog-workflows/.github/workflows/push-published-entries.yaml@v1
+    uses: hatena/hatenablog-workflows/.github/workflows/push-published-entries.yaml@fa544a63e845030ff65e35d78847e2bc2cab981e # v2.0.2
     secrets:
       OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}

--- a/.github/workflows/push-when-publishing-from-draft.yaml
+++ b/.github/workflows/push-when-publishing-from-draft.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   push-when-publishing-from-draft:
-    uses: hatena/hatenablog-workflows/.github/workflows/push-when-publishing-from-draft.yaml@v1
+    uses: hatena/hatenablog-workflows/.github/workflows/push-when-publishing-from-draft.yaml@fa544a63e845030ff65e35d78847e2bc2cab981e # v2.0.2
     with:
       BLOG_DOMAIN: ${{ vars.BLOG_DOMAIN }}
     secrets:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   push:
-    uses: hatena/hatenablog-workflows/.github/workflows/push.yaml@v1
+    uses: hatena/hatenablog-workflows/.github/workflows/push.yaml@fa544a63e845030ff65e35d78847e2bc2cab981e # v2.0.2
     with:
       local_root: "entries"
     secrets:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ default:
 
 ## Boilerplateに新しく追加されたWorkflowを取得する
 
-- workflowの変更は原則 [Reusable workflows](https://github.com/hatena/hatenablog-workflows) を変更するため基本的には更新は不要です
+- workflowの変更は [hatena/hatenablog-workflows](https://github.com/hatena/hatenablog-workflows) を更新することによって提供されますので、GitHub Actionsの参照を更新していただくことで、機能の更新を利用できます。
 - ただし、新しくworkflowが追加されたりした場合は、Boilerplateを元に作成されたリポジトリに新しいファイルを追加したり既存のファイルを更新する必要があります
 - 新しいファイルを取得するには`scripts/download_boilerplate_workflows.sh`を実行してください
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ default:
     - ![Actionsタブ、workflowリスト、Run workflowボタン](https://cdn-ak.f.st-hatena.com/images/fotolife/h/hatenablog/20231107/20231107163433.png)
 9. はてなブログの「[設定 > 編集モード](https://blog.hatena.ne.jp/my/config#blog-config-syntax)」設定を「Markdownモード」に設定する
 
+### Renovate / Dependabot のセットアップ
+
+- ワークフローの機能は[hatena/hatenablog-workflows](https://github.com/hatena/hatenablog-workflows)のReusable Workflowを呼び出すことで提供されています
+- hatenablog-workflows の機能追加やバグ修正を反映するにはGitHub Actionsの参照を更新する必要があり、自動的な更新にRenovateやDependabotをご利用いただけます
+- それぞれのセットアップ方法はドキュメントをご参照ください
+  - Renovate: [Automated Dependency Updates for GitHub Actions - Renovate Docs](https://docs.renovatebot.com/modules/manager/github-actions/)
+  - Dependabot: [Dependabot でアクションを最新に保つ - GitHub Docs](https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
+
 ## オプション
 - 下書きの作成時のプルリクエストをドラフトプルリクエストとして作成するかどうかのオプション
   - ドラフトプルリクエストは[利用できるプランに制限](https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request)があります。対象外のプランを利用している場合、以下のファイルの該当行を `draft: false` に変更してください 
@@ -94,6 +102,41 @@ default:
 ### 既存記事を修正する場合
 
 - 修正ブランチを作成し、main ブランチにマージすると修正がはてなブログに反映されます
+
+
+## 予約投稿について
+
+- はてなブログでは記事の予約投稿が利用可能ですが、このBoilerplateから記事の予約投稿を行うことはできません。記事を予約投稿するには、はてなブログの記事の編集画面から設定を行ってください。
+  - [日時を指定して予約投稿する（編集オプション） - はてなブログ ヘルプ https://help.hatenablog.com/entry/editor/publish/schedule]
+  - ※予約投稿の設定を行ったあと、記事が投稿されるまでにこのワークフローを経由して記事の変更を行うと、予約投稿の設定が解除されてしまいますのでご注意ください
+- リポジトリで管理していた記事を予約投稿する場合、以下のいずれかの手順で予約投稿による変更を同期して頂く必要があります。
+
+### プルリクエストをマージする方法
+1. プルリクエストをデフォルトブランチにマージする
+  - この際、`draft:true` を削除してはいけません
+2. はてなブログ側で予約投稿を行う
+3. 記事が公開されたら `pull form hatenablog` アクションを実行する
+4. `/draft_entries` から予約投稿記事を削除する
+
+### プルリクエストをクローズする方法
+1. プルリクエストをクローズする
+2. はてなブログ側で予約投稿を行う
+3. 記事が公開されたら `pull from hatenablog` アクションを実行する
+
+
+## プルリクエストテンプレートを利用する
+
+- `create draft` アクションまたは `pull draft from hatenablog` アクションによってプルリクエストを作成する際、リポジトリに `.github/PULL_REQUEST_TEMPLATE.md` または `.github/PULL_REQUEST_TEMPLATE/draft.md` という名前のテンプレートファイルが存在すれば、そのテンプレートを利用してプルリクエストが作成されます。
+- プルリクエストテンプレートでは以下のプレースホルダが利用可能です。これらのプレースホルダはプルリクエストの作成時には記事に固有の値に置き換えられます
+
+| プレースホルダ | 値 |
+| :------------: | :----: |
+| `${EDIT_URL}`   | 下書き記事の編集画面のURL |
+| `${PREVIEW_URL}` | 下書き記事のプレビューURL（まだプレビューURLがない場合は `なし`） |
+| `${TITLE}` | 下書き記事の記事タイトル |
+| `${ENTRY_ID}` | 下書き記事のID |
+| `${OWNER_NAME}` | ブログのオーナーのアカウント名 |
+
 
 ## Boilerplateに新しく追加されたWorkflowを取得する
 


### PR DESCRIPTION
- READMEにGitHub Actionsの更新・予約投稿・プルリクエストテンプレートについての記述を追加
- プルリクエストテンプレートを追加